### PR TITLE
feat: modify package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,17 +44,13 @@
     "dependencies": {
         "cosmiconfig": "^5.0.7",
         "debug": "^4.1.0",
-        "get-stdin": "^6.0.0",
         "globby": "^8.0.1",
         "ignore": "^5.0.4",
-        "import-local": "^2.0.0",
-        "meow": "^5.0.0",
         "pify": "^4.0.1",
         "prettier": "^1.7.0",
         "resolve-from": "^4.0.0",
         "stylelint": "^9.9.0",
         "temp-write": "^3.3.0",
-        "tempy": "^0.2.1",
         "update-notifier": "^2.2.0"
     },
     "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -34,15 +34,15 @@
         "conventional-changelog-cli": "^2.0.11",
         "eslint": "^4.19.0",
         "eslint-config-halo": "^2.4.1",
+	"get-stdin": "^6.0.0",
         "http-serve": "^1.0.1",
         "husky": "^1.2.0",
+	"import-local": "^2.0.0",
+        "meow": "^5.0.0",
         "np": "^3.0.4",
         "npm-run-all": "^4.1.1",
         "nyc": "^13.1.0",
         "stylelint-config-recommended": "^2.1.0",
-	"import-local": "^2.0.0",
-        "meow": "^5.0.0",
-	"get-stdin": "^6.0.0",
 	"tempy": "^0.2.1"
     },
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,11 @@
         "np": "^3.0.4",
         "npm-run-all": "^4.1.1",
         "nyc": "^13.1.0",
-        "stylelint-config-recommended": "^2.1.0"
+        "stylelint-config-recommended": "^2.1.0",
+	"import-local": "^2.0.0",
+        "meow": "^5.0.0",
+	"get-stdin": "^6.0.0",
+	"tempy": "^0.2.1"
     },
     "dependencies": {
         "cosmiconfig": "^5.0.7",


### PR DESCRIPTION
Hi,

Thanks for developing this good project, which provides high-coverage tests.

I'm doing dynamic analysis on npm packages, and your project is one of my samples.

Through our dynamic analysis by running the test suites, we find that 4/14 of the direct dependencies are installed, however, they are not used during test runtime, indicating that they are development dependencies.  So we moved these dependencies from `dependencies` to `devDependencies` in package.json.

Would you consider creating a modified version of the package.json, which can help reduce the corresponding maintenance costs and security risks in production?